### PR TITLE
Treat longs like ints

### DIFF
--- a/refreshbooks/adapters.py
+++ b/refreshbooks/adapters.py
@@ -5,7 +5,7 @@ from refreshbooks import elements, client
 
 # To make life nicer for clients, allow built-in numeric-alike types
 # in API parameters.
-_stringable_types = frozenset([float, int, decimal.Decimal])
+_stringable_types = frozenset([float, int, long, decimal.Decimal])
 
 def encode_as_simple_from_element(name, value):
     """Creates an etree element following the simple field convention. To 

--- a/refreshbooks/adapters.py
+++ b/refreshbooks/adapters.py
@@ -1,11 +1,15 @@
 from lxml import etree, objectify
 import decimal
+import sys
 
 from refreshbooks import elements, client
 
 # To make life nicer for clients, allow built-in numeric-alike types
 # in API parameters.
-_stringable_types = frozenset([float, int, long, decimal.Decimal])
+if sys.version_info.major >= 3:
+    _stringable_types = frozenset([float, int, decimal.Decimal])
+else:
+    _stringable_types = frozenset([float, int, long, decimal.Decimal])
 
 def encode_as_simple_from_element(name, value):
     """Creates an etree element following the simple field convention. To 


### PR DESCRIPTION
Without this change, doing something like `api.invoice.get(invoice_id=5L)` results in the following exception:
`encode_as_list_of_dicts() argument after * must be a sequence, not long`
